### PR TITLE
feat: add simple display reminder to event

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ $event = NowCal::create(['start' => 'October 5, 2019 6:03PM']))
 The following properties can be get/set on the NowCal instance. Users can take advantage of the set property helpers in the class, i.e.: `$nowcal->location('Event Location');` as they provide a nice syntax to string multiple calls together and support callbacks if necessary.
 
 | Property | Description                                                                                                                         |
-| -------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+|----------|-------------------------------------------------------------------------------------------------------------------------------------|
 | uid      | A globally unique ID. NOTE: passing the same ICS file into a calendar app with the same UI allows you to update the existing invite |
 | start    | A string parseable by DateTime                                                                                                      |
 | timezone | A string parseable by DateTimeZone                                                                                                  |
@@ -38,6 +38,7 @@ The following properties can be get/set on the NowCal instance. Users can take a
 | location | The location where the event is taking place                                                                                        |
 | sequence | An integer that represents the version number                                                                                       |
 | method   | send if required, publish/cancel/etc                                                                                                |
+| reminder | A simple display reminder. A string parseable by DateInterval.                                                                      |
 
 ### Methods
 

--- a/src/NowCal/NowCal.php
+++ b/src/NowCal/NowCal.php
@@ -433,7 +433,13 @@ class NowCal
     protected function merge(array $props): void
     {
         foreach ($props as $key => $val) {
-            $this->set($key, $val);
+
+            if (method_exists($this, $key)){
+                // The target parameter has specific setter method, use it because it contains casting logic
+                $this->$key($val);
+            }else{
+                $this->set($key, $val);
+            }
         }
     }
 

--- a/tests/NowCal/NowCalTest.php
+++ b/tests/NowCal/NowCalTest.php
@@ -36,7 +36,7 @@ class NowCalTest extends TestCase
         $this->nowcal->duration($time = '1h');
         $this->assertEquals($time, $this->nowcal->duration);
 
-        $this->nowcal->duration($time = new DateInterval('PT1H'));
+        $this->nowcal->duration(new DateInterval('PT1H'));
         $this->assertEquals('PT1H', $this->nowcal->duration);
     }
 
@@ -170,5 +170,37 @@ class NowCalTest extends TestCase
         $this->nowcal->method($method = 'request');
 
         $this->assertEquals($method, $this->nowcal->method);
+    }
+
+    public function test_it_can_set_a_reminder_with_simple_string()
+    {
+        $this->nowcal->reminder('15m');
+
+        $this->assertStringContainsString('BEGIN:VALARM', $this->nowcal->plain);
+        $this->assertStringContainsString('TRIGGER:-PT15M', $this->nowcal->plain);
+        $this->assertStringContainsString('ACTION:DISPLAY', $this->nowcal->plain);
+        $this->assertStringContainsString('DESCRIPTION:Reminder', $this->nowcal->plain);
+        $this->assertStringContainsString('END:VALARM', $this->nowcal->plain);
+    }
+
+    public function test_it_can_set_a_reminder_with_iso8601_string()
+    {
+        $this->nowcal->reminder( 'PT30M');
+
+        $this->assertStringContainsString('BEGIN:VALARM', $this->nowcal->plain);
+        $this->assertStringContainsString('TRIGGER:-PT30M', $this->nowcal->plain);
+        $this->assertStringContainsString('ACTION:DISPLAY', $this->nowcal->plain);
+        $this->assertStringContainsString('DESCRIPTION:Reminder', $this->nowcal->plain);
+        $this->assertStringContainsString('END:VALARM', $this->nowcal->plain);
+    }
+    public function test_it_can_set_a_reminder_with_DateInterval()
+    {
+        $this->nowcal->reminder(new DateInterval('PT1H'));
+
+        $this->assertStringContainsString('BEGIN:VALARM', $this->nowcal->plain);
+        $this->assertStringContainsString('TRIGGER:-PT1H', $this->nowcal->plain);
+        $this->assertStringContainsString('ACTION:DISPLAY', $this->nowcal->plain);
+        $this->assertStringContainsString('DESCRIPTION:Reminder', $this->nowcal->plain);
+        $this->assertStringContainsString('END:VALARM', $this->nowcal->plain);
     }
 }

--- a/tests/NowCal/NowCalTest.php
+++ b/tests/NowCal/NowCalTest.php
@@ -181,6 +181,16 @@ class NowCalTest extends TestCase
         $this->assertStringContainsString('ACTION:DISPLAY', $this->nowcal->plain);
         $this->assertStringContainsString('DESCRIPTION:Reminder', $this->nowcal->plain);
         $this->assertStringContainsString('END:VALARM', $this->nowcal->plain);
+
+        $actual = NowCal::plain([
+            'reminder' => '30m',
+        ]);
+
+        $this->assertStringContainsString('BEGIN:VALARM', $actual);
+        $this->assertStringContainsString('TRIGGER:-PT30M', $actual);
+        $this->assertStringContainsString('ACTION:DISPLAY', $actual);
+        $this->assertStringContainsString('DESCRIPTION:Reminder', $actual);
+        $this->assertStringContainsString('END:VALARM', $actual);
     }
 
     public function test_it_can_set_a_reminder_with_iso8601_string()


### PR DESCRIPTION
# What was changed?

Add a new api `reminder()` for triggering display notification before the calendar event happens. The api `reminder()` supports using ISO8601 Period format or DateInterval object.

- For ISO8601 format: ie. PT15M is 15 minutes before the event. PT1H is 1 hour before the event. 
- For DateInterval object, see https://www.php.net/manual/en/class.dateinterval.php for reference.