### PR TITLE
fix: outlook import ics missing description issue

### DIFF
--- a/src/NowCal/NowCal.php
+++ b/src/NowCal/NowCal.php
@@ -41,6 +41,7 @@ class NowCal
     public const ALLOWED = [
         'end',
         'uid',
+        'description',
         'start',
         'method',
         'summary',
@@ -48,9 +49,8 @@ class NowCal
         'duration',
         'sequence',
         'timezone',
-        'reminder',
         'organizer',
-        'description',
+        'reminder',
     ];
 
     /**

--- a/tests/NowCal/NowCalTest.php
+++ b/tests/NowCal/NowCalTest.php
@@ -213,4 +213,19 @@ class NowCalTest extends TestCase
         $this->assertStringContainsString('DESCRIPTION:Reminder', $this->nowcal->plain);
         $this->assertStringContainsString('END:VALARM', $this->nowcal->plain);
     }
+
+    public function test_it_includes_description_before_reminder()
+    {
+        $description = 'This is a test description';
+        $this->nowcal->description($description);
+        $this->nowcal->reminder( 'PT30M');
+
+        $expectedDescriptionProperty = 'DESCRIPTION:'.$description;
+        $this->assertStringContainsString($expectedDescriptionProperty, $this->nowcal->plain);
+        $this->assertStringContainsString('BEGIN:VALARM', $this->nowcal->plain);
+
+        $descriptionIndex = strpos($this->nowcal->plain, $expectedDescriptionProperty);
+        $reminderStartIndex = strpos($this->nowcal->plain, 'BEGIN:VALARM');
+        $this->assertTrue($descriptionIndex < $reminderStartIndex);
+    }
 }


### PR DESCRIPTION
# Issue

When importing the ICS into MacOS outlook app, it shows the calendar event info no problem during preview. But after the event is imported, the description info is gone. 

After some investigation, it appears that some verisons of Outlook cannot correctly parse event description if they appear after VALARM. So, the changes here is to move reminder to the bottom of the ALLOWED property, so we only append VALARM in the end of the ICS file. 

# Testing
1. Generate an ICS with description and reminder.
2. Import the ICS into Outlook app 
3. Make sure the event description is properly displayed.